### PR TITLE
fix(slack): fixing an error in the OAuth callback and refactoring the…

### DIFF
--- a/app/core/slack.py
+++ b/app/core/slack.py
@@ -18,7 +18,7 @@ async def oauth_success(args):
         installation.team_id,
         installation.user_id,
     )
-    return await args.default_callback_options.success(args)
+    return await args.default.success(args)
 
 
 async def oauth_failure(args):
@@ -27,7 +27,7 @@ async def oauth_failure(args):
         args.reason,
         args.request.query.get("state"),
     )
-    return await args.default_callback_options.failure(args)
+    return await args.default.failure(args)
 
 
 oauth_settings = AsyncOAuthSettings(


### PR DESCRIPTION
## 📝 PR Summary*
- Fixes an AttributeError in `oauth_success` and `oauth_failure` when accessing the default handlers through `args.default` instead of `args.default_callback_options`.

- Refactors `SlackOAuthService.save_installation` to avoid redundant `update` calls immediately after creating a new installation.

- Ensures that all installation fields (tokens, IDs, and scopes) are correctly populated during both creation and update.

## 🎯 Context/Motivation*
Why is this change needed? What problem or goal does it address?

## 🔗 Related issues
- Closes #
- Relates to #

## 🧩 Type of change*
- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (refactoring with no behavior change)
- [ ] perf (performance improvement)
- [ ] docs (documentation)
- [ ] test (add/adjust tests)
- [ ] chore/build/ci (infra, dependencies, scripts, CI)

## ✅ Author Checklist*
- [ ] Clear title and well-defined scope
- [ ] Description and motivation filled in
- [ ] Linked issue(s) when applicable
- [ ] Adequate test coverage (unit and/or integration)
- [ ] Ran `pytest` locally with no failures
- [ ] Ran linters/formatters (e.g., `ruff`, `black`, `isort`) if applicable
- [ ] Documentation updated (README, docstrings, comments) when needed
- [ ] Alembic migrations created/applied when needed
- [ ] Backwards compatibility considered (APIs, schemas, contracts)
- [ ] Security and sensitive data reviewed (e.g., environment variables, secrets)
- [ ] Performance impact assessed (N+1, queries, loops)
